### PR TITLE
Cleanup

### DIFF
--- a/src/Data/Vector/FFT.hs
+++ b/src/Data/Vector/FFT.hs
@@ -16,27 +16,23 @@ import Data.Complex (Complex(..), conjugate)
 import Data.Foldable (forM_)
 
 import Data.Vector.Unboxed as V (Vector, Unbox, map, zipWith, length, unsafeFreeze, (!))
-import qualified Data.Vector.Unboxed.Mutable as VM (MVector, read, write, new, length)
+import qualified Data.Vector.Unboxed.Mutable as VM (MVector, generate, read, write, swap, new, length)
 import qualified Data.Vector.Generic as VG (Vector(..), copy)
 
 import Prelude hiding (read)
 
 
--- | (Circular) cross-correlation of two vectors
+-- | (Circular) cross-correlation of two vectors.
 --
--- Defined via the FFT and IFFT for computational efficiency
+-- Defined via the FFT and IFFT for computational efficiency.
 --
--- NB the source vectors should have matching length for meaningful results
-crossCorrelation :: Vector (Complex Double)
-                 -> Vector (Complex Double)
-                 -> Vector (Complex Double)
+-- NB: the source vectors should have matching length for meaningful results.
+crossCorrelation :: Vector (Complex Double) -> Vector (Complex Double) -> Vector (Complex Double)
 crossCorrelation v1 v2 = ifft $ (cmap conjugate v1hat) `prod` v2hat
   where
     prod = V.zipWith (*)
     v1hat = fft v1
     v2hat = fft v2
-
-
 
 -- | Radix-2 decimation-in-time fast Fourier Transform.
 --
@@ -57,72 +53,57 @@ ifft arr = do
   cmap ((/ lenComplex) . conjugate) . fft . cmap conjugate $ arr
 {-# inlinable [1] ifft #-}
 
-
-
-
 -- | Copy the source vector into a zero-padded mutable one
-copyPadded :: (PrimMonad m, Num a, Unbox a) =>
-              Vector a -> m (VM.MVector (PrimState m) a)
+copyPadded :: (PrimMonad m, Num a, Unbox a) => Vector a -> m (VM.MVector (PrimState m) a)
 copyPadded arr = do
-  let
-    len = V.length arr
-    l2 = nextPow2 len
-  marr <- VM.new l2
-  forM_ [0 .. l2 - 1] $ \i -> do
-    let x | i < len = arr V.! i
-          | otherwise = 0
-    VM.write marr i x
-  pure marr
+  let len = V.length arr
+  VM.generate (nextPow2 len) $ \i -> if i < len then arr V.! i else 0
 {-# inline copyPadded #-}
-
-
-
-
 
 -- | Radix-2 decimation-in-time fast Fourier Transform.
 --   The given array must have a length that is a power of two,
 --   though this property is not checked.
 mfft :: (PrimMonad m) => VM.MVector (PrimState m) (Complex Double) -> m ()
-mfft mut = do {
-    let len = VM.length mut
-  ; let bitReverse !i !j = do {
-          ; if i == len - 1
-              then stage 0 1
-              else do {
-                  when (i < j) $ swap mut i j
-                ; let inner k l = if k <= l
-                        then inner (k `shiftR` 1) (l - k)
-                        else bitReverse (i + 1) (l + k)
-                ; inner (len `shiftR` 1) j
-              }
-        }
-        stage l l1 = if l == (log2 len)
-          then pure ()
-          else do {
-              let !l2 = l1 `shiftL` 1
-                  !e = (negate twoPi) / (intToDouble l2)
-                  flight j !a = if j == l1
-                    then stage (l + 1) l2
-                    else do {
-                        let butterfly i = if i >= len
-                              then flight (j + 1) (a + e)
-                              else do {
-                                  let i1 = i + l1
-                                ; xi1 :+ yi1 <- VM.read mut i1
-                                ; let !co = cos a
-                                      !si = sin a
-                                      d = (co * xi1 - si * yi1) :+ (si * xi1 + co * yi1)
-                                ; ci <- VM.read mut i
-                                ; VM.write mut i1 (ci - d)
-                                ; VM.write mut i (ci + d)
-                                ; butterfly (i + l2)
-                              }
-                      ; butterfly j
-                    }
-            ; flight 0 0
-         }
-  ; when (len > 0) $ bitReverse 0 0
-}
+mfft mut = do
+    let
+      len = VM.length mut
+
+      -- bit reversal permutation
+      -- i is the original index
+      -- j is the bit-reversed index
+      reverseIndices !i !j
+        | i == len - 1 = stage 0 1
+        | otherwise = do
+            when (i < j) $ VM.swap mut i j
+            let inner k l
+                  | k <= l = inner (k `shiftR` 1) (l - k)
+                  | otherwise = reverseIndices (i + 1) (l + k)
+            inner (len `shiftR` 1) j
+
+      stage l l1
+        | l == (log2 len) = pure ()
+        | otherwise = do
+            let !l2 = l1 `shiftL` 1
+                !e = (-2 * pi) / (intToDouble l2)
+                flight j !a
+                  | j == l1 = stage (l + 1) l2
+                  | otherwise = do
+                      let butterfly i
+                            | i >= len = flight (j + 1) (a + e)
+                            | otherwise = do
+                                let i1 = i + l1
+                                xi1 :+ yi1 <- VM.read mut i1
+                                let !co = cos a
+                                    !si = sin a
+                                    d = (co * xi1 - si * yi1) :+ (si * xi1 + co * yi1)
+                                ci <- VM.read mut i
+                                VM.write mut i1 (ci - d)
+                                VM.write mut i (ci + d)
+                                butterfly (i + l2)
+                      butterfly j
+            flight 0 0
+
+    when (len > 0) $ reverseIndices 0 0
 
 -- | Next power of 2
 nextPow2 :: Int -> Int
@@ -131,23 +112,9 @@ nextPow2 n
   | n .&. (n - 1) == 0 = n
   | otherwise = 1 `shiftL` (log2 n + 1)
 
-
 log2 :: Int -> Int
 log2 n = finiteBitSize (0 :: Int) - 1 - countLeadingZeros n
 
-
-{-# inline swap #-}
-swap :: (PrimMonad m, Unbox a) =>
-        VM.MVector (PrimState m) a -> Int -> Int -> m ()
-swap mut i j = do
-  atI <- VM.read mut i
-  atJ <- VM.read mut j
-  VM.write mut i atJ
-  VM.write mut j atI
-
-twoPi :: Double
-{-# inline twoPi #-}
-twoPi = 6.283185307179586
 
 intToDouble :: Int -> Double
 {-# inline intToDouble #-}


### PR DESCRIPTION
* ~~Use `V.create` instead of `runST` & `V.unsafeFreeze`~~ this actually makes it a lot slower
* Use `VM.generate` in `copyPadded`
* Use `VM.swap` instead of redefining it
* Use `2 * pi` instead of a `twoPi` constant (this gets constant folded anyway)
* Format `mfft` to avoid braces and semicolons
* Rename `bitReverse` to `reverseIndices` and add a small comment
* Remove some blank lines