### PR TITLE
Generalize to `RealFloat a => Complex a`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 next
 
+* generalize `fft`/`ifft`/`crossCorrelation` to work with any `RealFloat a => Complex a`
+
+0.2.0.0
+
 * remove broken rewrite rules
 * fix `fft`/`ifft`/`crossCorrelation` for vectors whose length is not a power of two
 


### PR DESCRIPTION
Generalize `fft`/`ifft`/`crossCorrelation` to work with any `(RealFloat a, Unbox a) => Complex a`. This allows the functions to also be used with `Complex Float`. Add specialize pragmas for `Double` & `Float`, to retain the original performance.